### PR TITLE
feat: use latency class with max aggregation for polling-latency-usec

### DIFF
--- a/hwnoise-post-process
+++ b/hwnoise-post-process
@@ -38,7 +38,7 @@ def main():
 
     period = { 'name': 'measurement', 'metric-files': [] }
     file_id = '0'
-    desc = {'source':'hwnoise', 'class':'count', 'type':'polling-latency-usec'}
+    desc = {'source':'hwnoise', 'class':'latency', 'type':'polling-latency-usec', 'default-aggregation':'max'}
     names = {}
 
     time = {"begin": None, "end": None}


### PR DESCRIPTION
## Summary
- Migrate `polling-latency-usec` from `class=count` to `class=latency` with `default-aggregation=max`
- Max aggregation ensures the highest hardware noise latency across engines is reported

Part of [PERFNFV-413](https://redhat.atlassian.net/browse/PERFNFV-413) / epic [PERFNFV-409](https://redhat.atlassian.net/browse/PERFNFV-409)

## Test plan
- [ ] Verify metric indexed with `class=latency` and `default-aggregation=max`

🤖 Generated with [Claude Code](https://claude.com/claude-code)